### PR TITLE
ci:添加工作流以自动更新子模块指针

### DIFF
--- a/.github/workflows/update-submodule.yml
+++ b/.github/workflows/update-submodule.yml
@@ -1,10 +1,6 @@
 name: Update submodule
 
 on:
-  repository_dispatch:
-    types:
-      - submodule-updated
-      - update-submodule
   workflow_dispatch:
     inputs:
       path:

--- a/.github/workflows/update-submodule.yml
+++ b/.github/workflows/update-submodule.yml
@@ -18,7 +18,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: update-submodule-${{ github.event.client_payload.path || inputs.path || 'tauri/src' }}
+  group: update-submodule-${{ inputs.path || 'tauri/src' }}
   cancel-in-progress: false
 
 jobs:
@@ -37,18 +37,15 @@ jobs:
         id: target
         shell: bash
         env:
-          DISPATCH_PATH: ${{ github.event.client_payload.path }}
-          DISPATCH_REF: ${{ github.event.client_payload.ref }}
-          DISPATCH_SHA: ${{ github.event.client_payload.sha }}
           INPUT_PATH: ${{ inputs.path }}
           INPUT_REF: ${{ inputs.ref }}
           INPUT_SHA: ${{ inputs.sha }}
         run: |
           set -euo pipefail
 
-          path="${DISPATCH_PATH:-${INPUT_PATH:-tauri/src}}"
-          ref="${DISPATCH_REF:-${INPUT_REF:-}}"
-          sha="${DISPATCH_SHA:-${INPUT_SHA:-}}"
+          path="${INPUT_PATH:-tauri/src}"
+          ref="${INPUT_REF:-}"
+          sha="${INPUT_SHA:-}"
 
           if ! git config --file .gitmodules --get-regexp '^submodule\..*\.path$' | awk '{print $2}' | grep -Fxq "$path"; then
             echo "::error::'$path' is not a configured submodule path"
@@ -97,9 +94,25 @@ jobs:
             exit 0
           fi
 
-          new_sha="$(git -C "$SUBMODULE_PATH" rev-parse --short=12 HEAD)"
+          old_sha="$(git rev-parse "HEAD:${SUBMODULE_PATH}")"
+          new_sha="$(git -C "$SUBMODULE_PATH" rev-parse HEAD)"
+          commit_message="$(mktemp)"
+
+          printf '%s\n' '同步上游更改' > "$commit_message"
+          if ! git -C "$SUBMODULE_PATH" log --reverse \
+            --format='- [%h] + %s' "${old_sha}..${new_sha}" \
+            >> "$commit_message"; then
+            echo "::error::Unable to read submodule commits between ${old_sha} and ${new_sha}"
+            exit 1
+          fi
+
+          if [ "$(wc -l < "$commit_message")" -eq 1 ]; then
+            git -C "$SUBMODULE_PATH" log -1 \
+              --format='- [%h] + %s' "$new_sha" \
+              >> "$commit_message"
+          fi
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git commit -m "chore: update ${SUBMODULE_PATH} submodule to ${new_sha}"
+          git commit --file "$commit_message"
           git push

--- a/.github/workflows/update-submodule.yml
+++ b/.github/workflows/update-submodule.yml
@@ -1,0 +1,109 @@
+name: Update submodule
+
+on:
+  repository_dispatch:
+    types:
+      - submodule-updated
+      - update-submodule
+  workflow_dispatch:
+    inputs:
+      path:
+        description: Submodule path to update
+        required: false
+        default: tauri/src
+      ref:
+        description: Optional branch, tag, or ref to check out in the submodule
+        required: false
+      sha:
+        description: Optional exact commit SHA to check out in the submodule
+        required: false
+
+permissions:
+  contents: write
+
+concurrency:
+  group: update-submodule-${{ github.event.client_payload.path || inputs.path || 'tauri/src' }}
+  cancel-in-progress: false
+
+jobs:
+  update-submodule:
+    name: Update submodule pointer
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Resolve update target
+        id: target
+        shell: bash
+        env:
+          DISPATCH_PATH: ${{ github.event.client_payload.path }}
+          DISPATCH_REF: ${{ github.event.client_payload.ref }}
+          DISPATCH_SHA: ${{ github.event.client_payload.sha }}
+          INPUT_PATH: ${{ inputs.path }}
+          INPUT_REF: ${{ inputs.ref }}
+          INPUT_SHA: ${{ inputs.sha }}
+        run: |
+          set -euo pipefail
+
+          path="${DISPATCH_PATH:-${INPUT_PATH:-tauri/src}}"
+          ref="${DISPATCH_REF:-${INPUT_REF:-}}"
+          sha="${DISPATCH_SHA:-${INPUT_SHA:-}}"
+
+          if ! git config --file .gitmodules --get-regexp '^submodule\..*\.path$' | awk '{print $2}' | grep -Fxq "$path"; then
+            echo "::error::'$path' is not a configured submodule path"
+            exit 1
+          fi
+
+          {
+            echo "path=$path"
+            echo "ref=$ref"
+            echo "sha=$sha"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Update submodule
+        shell: bash
+        env:
+          SUBMODULE_PATH: ${{ steps.target.outputs.path }}
+          SUBMODULE_REF: ${{ steps.target.outputs.ref }}
+          SUBMODULE_SHA: ${{ steps.target.outputs.sha }}
+        run: |
+          set -euo pipefail
+
+          git submodule sync --recursive "$SUBMODULE_PATH"
+          git submodule update --init --recursive "$SUBMODULE_PATH"
+
+          if [ -n "$SUBMODULE_SHA" ]; then
+            git -C "$SUBMODULE_PATH" fetch origin "$SUBMODULE_SHA"
+            git -C "$SUBMODULE_PATH" checkout --detach "$SUBMODULE_SHA"
+          elif [ -n "$SUBMODULE_REF" ]; then
+            git -C "$SUBMODULE_PATH" fetch origin "$SUBMODULE_REF"
+            git -C "$SUBMODULE_PATH" checkout --detach FETCH_HEAD
+          else
+            git submodule update --remote --recursive "$SUBMODULE_PATH"
+          fi
+
+          git add "$SUBMODULE_PATH"
+
+      - name: Commit and push
+        shell: bash
+        env:
+          SUBMODULE_PATH: ${{ steps.target.outputs.path }}
+        run: |
+          set -euo pipefail
+
+          if git diff --cached --quiet; then
+            echo "Submodule is already up to date."
+            exit 0
+          fi
+
+          new_sha="$(git -C "$SUBMODULE_PATH" rev-parse --short=12 HEAD)"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "chore: update ${SUBMODULE_PATH} submodule to ${new_sha}"
+          git push


### PR DESCRIPTION
添加一个新的 GitHub Actions 工作流，通过 `repository_dispatch` 或手动 `workflow_dispatch` 更新子模块提交。

该工作流会验证目标子模块路径，支持按路径/引用/sha 更新，仅在指针更改时提交，并使用 GitHub Actions 机器人推送。这使得子模块更新保持一致且可审计，无需手动本地提交。