### PR TITLE
ci: add path filter for build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,6 +2,12 @@ name: Build
 
 on:
   push:
+    paths:
+      - 'tauri/**'
+      - '**.js'
+      - '**.json'
+      - '.gitmodules'
+      - '.github/workflows/**'
   pull_request:
 
 concurrency:
@@ -17,20 +23,20 @@ jobs:
         include:
           - name: macOS (Apple Silicon)
             platform: macos-latest
-            args: "--target aarch64-apple-darwin"
+            args: '--target aarch64-apple-darwin'
             rust-targets: aarch64-apple-darwin
           - name: macOS (Intel)
             platform: macos-latest
-            args: "--target x86_64-apple-darwin"
+            args: '--target x86_64-apple-darwin'
             rust-targets: x86_64-apple-darwin
           - name: Linux (x86_64)
             platform: ubuntu-22.04
-            args: "--bundles appimage,deb,rpm"
-            rust-targets: ""
+            args: '--bundles appimage,deb,rpm'
+            rust-targets: ''
           - name: Windows (x86_64)
             platform: windows-latest
-            args: ""
-            rust-targets: ""
+            args: ''
+            rust-targets: ''
 
     uses: ./.github/workflows/_shared-build.yaml
     with:


### PR DESCRIPTION
为push事件触发的构建工作流添加了路径过滤器，使其只在更改了应用代码时才触发构建

---

没有更改pull_request触发器，因为根据 [GitHub文档](https://docs.github.com/zh/actions/reference/workflows-and-actions/workflow-syntax#example-including-paths)：

> If a workflow is skipped due to path filtering, [branch filtering](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpull_requestpull_request_targetbranchesbranches-ignore), or a [commit message](https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs), then checks associated with that workflow will remain in a "Pending" state. A pull request that requires those checks to be successful will be blocked from merging.

---

（另外Prettier自动把引号格式化了，不用管它（（