### PR TITLE
Fn/try to capture and use the built in browser in windows 12 when opening a browser on the desktop version

### DIFF
--- a/tauri/src-tauri/Cargo.lock
+++ b/tauri/src-tauri/Cargo.lock
@@ -4958,7 +4958,7 @@ dependencies = [
 
 [[package]]
 name = "win12-desktop"
-version = "0.2.1"
+version = "0.2.4"
 dependencies = [
  "argon2",
  "battery",

--- a/tauri/src-tauri/Cargo.toml
+++ b/tauri/src-tauri/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = [] }
+tauri = { version = "2", features = ["unstable"] }
 tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/tauri/src-tauri/capabilities/default.json
+++ b/tauri/src-tauri/capabilities/default.json
@@ -10,6 +10,8 @@
     "core:webview:allow-webview-hide",
     "core:webview:allow-webview-show",
     "core:webview:allow-set-webview-focus",
+    "core:webview:allow-set-webview-position",
+    "core:webview:allow-set-webview-size",
     "opener:default"
   ]
 }

--- a/tauri/src-tauri/capabilities/default.json
+++ b/tauri/src-tauri/capabilities/default.json
@@ -5,7 +5,7 @@
   "windows": ["main", "edge-*"],
   "permissions": [
     "core:default",
-    "core:webview:allow-create-webview-window",
+    "core:webview:allow-create-webview",
     "core:webview:allow-webview-close",
     "core:webview:allow-webview-hide",
     "core:webview:allow-webview-show",

--- a/tauri/src-tauri/capabilities/default.json
+++ b/tauri/src-tauri/capabilities/default.json
@@ -3,5 +3,13 @@
   "identifier": "default",
   "description": "Capability for the main window",
   "windows": ["main", "edge-*"],
-  "permissions": ["core:default", "opener:default"]
+  "permissions": [
+    "core:default",
+    "core:webview:allow-create-webview-window",
+    "core:webview:allow-webview-close",
+    "core:webview:allow-webview-hide",
+    "core:webview:allow-webview-show",
+    "core:webview:allow-set-webview-focus",
+    "opener:default"
+  ]
 }

--- a/tauri/src-tauri/capabilities/default.json
+++ b/tauri/src-tauri/capabilities/default.json
@@ -2,6 +2,6 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
   "description": "Capability for the main window",
-  "windows": ["main"],
+  "windows": ["main", "edge-*"],
   "permissions": ["core:default", "opener:default"]
 }

--- a/tauri/src-tauri/src/lib.rs
+++ b/tauri/src-tauri/src/lib.rs
@@ -435,6 +435,51 @@ fn write_settings(json: String) -> Result<(), String> {
     Ok(())
 }
 
+#[tauri::command]
+fn open_external_url(url: String) -> Result<bool, String> {
+    let url = url.trim();
+    if !(url.starts_with("https://") || url.starts_with("http://"))
+        || url.chars().any(|c| c.is_control() || c.is_whitespace())
+    {
+        return Err("Only HTTP(S) URLs can be opened".to_string());
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        let mut candidates = Vec::new();
+        if let Some(program_files) = std::env::var_os("ProgramFiles") {
+            candidates.push(PathBuf::from(program_files).join("Microsoft/Edge/Application/msedge.exe"));
+        }
+        if let Some(program_files_x86) = std::env::var_os("ProgramFiles(x86)") {
+            candidates.push(PathBuf::from(program_files_x86).join("Microsoft/Edge/Application/msedge.exe"));
+        }
+        if let Some(local_app_data) = std::env::var_os("LOCALAPPDATA") {
+            candidates.push(PathBuf::from(local_app_data).join("Microsoft/Edge/Application/msedge.exe"));
+        }
+
+        let edge = candidates
+            .into_iter()
+            .find(|path| path.is_file())
+            .ok_or("Microsoft Edge was not found".to_string())?;
+        let data_dir = dirs::data_dir().ok_or("Cannot find application data directory")?;
+        let profile_dir = data_dir.join("win12-desktop").join("browser-profile");
+        fs::create_dir_all(&profile_dir).map_err(|e| e.to_string())?;
+
+        Command::new(edge)
+            .arg(format!("--user-data-dir={}", profile_dir.display()))
+            .arg(format!("--app={url}"))
+            .spawn()
+            .map_err(|e| format!("Failed to start Microsoft Edge: {e}"))?;
+        return Ok(true);
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        let _ = url;
+        Err("System Microsoft Edge is only supported on Windows".to_string())
+    }
+}
+
 fn emit_ping_output(
     window: &tauri::Window,
     request_id: &str,
@@ -466,7 +511,8 @@ pub fn run() {
             verify_login_password,
             set_login_password,
             check_app_update,
-            ping_host
+            ping_host,
+            open_external_url
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/tauri/src-tauri/src/lib.rs
+++ b/tauri/src-tauri/src/lib.rs
@@ -435,51 +435,6 @@ fn write_settings(json: String) -> Result<(), String> {
     Ok(())
 }
 
-#[tauri::command]
-fn open_external_url(url: String) -> Result<bool, String> {
-    let url = url.trim();
-    if !(url.starts_with("https://") || url.starts_with("http://"))
-        || url.chars().any(|c| c.is_control() || c.is_whitespace())
-    {
-        return Err("Only HTTP(S) URLs can be opened".to_string());
-    }
-
-    #[cfg(target_os = "windows")]
-    {
-        let mut candidates = Vec::new();
-        if let Some(program_files) = std::env::var_os("ProgramFiles") {
-            candidates.push(PathBuf::from(program_files).join("Microsoft/Edge/Application/msedge.exe"));
-        }
-        if let Some(program_files_x86) = std::env::var_os("ProgramFiles(x86)") {
-            candidates.push(PathBuf::from(program_files_x86).join("Microsoft/Edge/Application/msedge.exe"));
-        }
-        if let Some(local_app_data) = std::env::var_os("LOCALAPPDATA") {
-            candidates.push(PathBuf::from(local_app_data).join("Microsoft/Edge/Application/msedge.exe"));
-        }
-
-        let edge = candidates
-            .into_iter()
-            .find(|path| path.is_file())
-            .ok_or("Microsoft Edge was not found".to_string())?;
-        let data_dir = dirs::data_dir().ok_or("Cannot find application data directory")?;
-        let profile_dir = data_dir.join("win12-desktop").join("browser-profile");
-        fs::create_dir_all(&profile_dir).map_err(|e| e.to_string())?;
-
-        Command::new(edge)
-            .arg(format!("--user-data-dir={}", profile_dir.display()))
-            .arg(format!("--app={url}"))
-            .spawn()
-            .map_err(|e| format!("Failed to start Microsoft Edge: {e}"))?;
-        return Ok(true);
-    }
-
-    #[cfg(not(target_os = "windows"))]
-    {
-        let _ = url;
-        Err("System Microsoft Edge is only supported on Windows".to_string())
-    }
-}
-
 fn emit_ping_output(
     window: &tauri::Window,
     request_id: &str,
@@ -511,8 +466,7 @@ pub fn run() {
             verify_login_password,
             set_login_password,
             check_app_update,
-            ping_host,
-            open_external_url
+            ping_host
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");


### PR DESCRIPTION
修复在desktop中点击外链无法跳转的问题 
修复方式:跳转到win12 edge浏览器

增强在desktop中的浏览器功能，调用系统浏览器访问网站实现可以访问不允许被嵌套的网站
以Github为演示
<img width="1923" height="1126" alt="image" src="https://github.com/user-attachments/assets/29a0250b-9696-4431-873f-ced2358267e7" />
