### PR TITLE
Linux flatpak

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,6 +6,11 @@ on:
       - 'tauri/**'
       - '**.js'
       - '**.json'
+      - 'io.github.win12_online.win12_desktop.yml'
+      - 'io.github.win12_online.win12_desktop.desktop'
+      - 'io.github.win12_online.win12_desktop.metainfo.xml'
+      - 'cargo-sources.json'
+      - 'images/**'
       - '.gitmodules'
       - '.github/workflows/**'
   pull_request:
@@ -44,3 +49,52 @@ jobs:
       args: ${{ matrix.args }}
       rust-targets: ${{ matrix.rust-targets }}
       name: ${{ matrix.name }}
+
+  build-flatpak:
+    name: Build Flatpak
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          submodules: recursive
+
+      - name: Install Flatpak dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y flatpak flatpak-builder
+          sudo flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+
+      - name: Build Flatpak
+        run: |
+          flatpak-builder \
+            --user \
+            --install \
+            --install-deps-from=flathub \
+            --force-clean \
+            --repo=flatpak-repo \
+            flatpak-build \
+            io.github.win12_online.win12_desktop.yml
+
+      - name: Test Flatpak installation
+        run: |
+          flatpak info io.github.win12_online.win12_desktop
+          flatpak run --command=sh io.github.win12_online.win12_desktop -c \
+            'test -x /app/bin/win12-desktop && test -x /app/bin/ping && test -x /app/bin/ping6'
+
+      - name: Create Flatpak bundle
+        run: |
+          flatpak build-bundle \
+            flatpak-repo \
+            win12-desktop.flatpak \
+            io.github.win12_online.win12_desktop \
+            --runtime-repo=https://flathub.org/repo/flathub.flatpakrepo
+
+      - name: Upload Flatpak artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: flatpak-bundles
+          path: win12-desktop.flatpak
+          if-no-files-found: error
+          retention-days: 5

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,6 +53,9 @@ jobs:
   build-flatpak:
     name: Build Flatpak
     runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/flathub-infra/flatpak-github-actions:gnome-50
+      options: --privileged
 
     steps:
       - name: Checkout
@@ -60,37 +63,21 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Install Flatpak dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y flatpak flatpak-builder appstream-compose
-          command -v appstream-compose
-          flatpak --user remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
-
       - name: Build Flatpak
-        run: |
-          flatpak-builder \
-            --user \
-            --install \
-            --install-deps-from=flathub \
-            --force-clean \
-            --repo=flatpak-repo \
-            flatpak-build \
-            io.github.win12_online.win12_desktop.yml
+        uses: flatpak/flatpak-github-actions/flatpak-builder@v6
+        with:
+          bundle: win12-desktop.flatpak
+          manifest-path: io.github.win12_online.win12_desktop.yml
+          artifact-name: flatpak-bundles
+          cache-key: flatpak-builder-${{ github.sha }}
+          upload-artifact: false
 
       - name: Test Flatpak installation
         run: |
+          flatpak --user install -y ./win12-desktop.flatpak
           flatpak info io.github.win12_online.win12_desktop
           flatpak run --command=sh io.github.win12_online.win12_desktop -c \
             'test -x /app/bin/win12-desktop && test -x /app/bin/ping && test -x /app/bin/ping6'
-
-      - name: Create Flatpak bundle
-        run: |
-          flatpak build-bundle \
-            flatpak-repo \
-            win12-desktop.flatpak \
-            io.github.win12_online.win12_desktop \
-            --runtime-repo=https://flathub.org/repo/flathub.flatpakrepo
 
       - name: Upload Flatpak artifact
         uses: actions/upload-artifact@v7

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -64,6 +64,8 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y flatpak flatpak-builder appstream-compose
+          sudo ln -sf /usr/libexec/appstreamcli-compose /usr/bin/appstream-compose
+          command -v appstream-compose
           flatpak --user remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
 
       - name: Build Flatpak

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -64,7 +64,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y flatpak flatpak-builder
-          sudo flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+          flatpak --user remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
 
       - name: Build Flatpak
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -64,7 +64,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y flatpak flatpak-builder appstream-compose
-          sudo ln -sf /usr/libexec/appstreamcli-compose /usr/bin/appstream-compose
           command -v appstream-compose
           flatpak --user remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -63,7 +63,7 @@ jobs:
       - name: Install Flatpak dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y flatpak flatpak-builder
+          sudo apt-get install -y flatpak flatpak-builder appstream-compose
           flatpak --user remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
 
       - name: Build Flatpak

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -73,6 +73,8 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y flatpak flatpak-builder appstream-compose
+          sudo ln -sf /usr/libexec/appstreamcli-compose /usr/bin/appstream-compose
+          command -v appstream-compose
           flatpak --user remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
 
       - name: Build Flatpak

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -73,7 +73,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y flatpak flatpak-builder appstream-compose
-          sudo ln -sf /usr/libexec/appstreamcli-compose /usr/bin/appstream-compose
           command -v appstream-compose
           flatpak --user remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -73,7 +73,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y flatpak flatpak-builder
-          sudo flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+          flatpak --user remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
 
       - name: Build Flatpak
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -62,6 +62,9 @@ jobs:
     name: Build Flatpak
     needs: confirm-release
     runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/flathub-infra/flatpak-github-actions:gnome-50
+      options: --privileged
 
     steps:
       - name: Checkout
@@ -69,37 +72,21 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Install Flatpak dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y flatpak flatpak-builder appstream-compose
-          command -v appstream-compose
-          flatpak --user remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
-
       - name: Build Flatpak
-        run: |
-          flatpak-builder \
-            --user \
-            --install \
-            --install-deps-from=flathub \
-            --force-clean \
-            --repo=flatpak-repo \
-            flatpak-build \
-            io.github.win12_online.win12_desktop.yml
+        uses: flatpak/flatpak-github-actions/flatpak-builder@v6
+        with:
+          bundle: win12-desktop.flatpak
+          manifest-path: io.github.win12_online.win12_desktop.yml
+          artifact-name: flatpak-bundles
+          cache-key: flatpak-builder-${{ github.sha }}
+          upload-artifact: false
 
       - name: Test Flatpak installation
         run: |
+          flatpak --user install -y ./win12-desktop.flatpak
           flatpak info io.github.win12_online.win12_desktop
           flatpak run --command=sh io.github.win12_online.win12_desktop -c \
             'test -x /app/bin/win12-desktop && test -x /app/bin/ping && test -x /app/bin/ping6'
-
-      - name: Create Flatpak bundle
-        run: |
-          flatpak build-bundle \
-            flatpak-repo \
-            win12-desktop.flatpak \
-            io.github.win12_online.win12_desktop \
-            --runtime-repo=https://flathub.org/repo/flathub.flatpakrepo
 
       - name: Upload Flatpak artifact
         uses: actions/upload-artifact@v7

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -72,7 +72,7 @@ jobs:
       - name: Install Flatpak dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y flatpak flatpak-builder
+          sudo apt-get install -y flatpak flatpak-builder appstream-compose
           flatpak --user remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
 
       - name: Build Flatpak

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -58,16 +58,66 @@ jobs:
       rust-targets: ${{ matrix.rust-targets }}
       name: ${{ matrix.name }}
 
+  build-flatpak:
+    name: Build Flatpak
+    needs: confirm-release
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          submodules: recursive
+
+      - name: Install Flatpak dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y flatpak flatpak-builder
+          sudo flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+
+      - name: Build Flatpak
+        run: |
+          flatpak-builder \
+            --user \
+            --install \
+            --install-deps-from=flathub \
+            --force-clean \
+            --repo=flatpak-repo \
+            flatpak-build \
+            io.github.win12_online.win12_desktop.yml
+
+      - name: Test Flatpak installation
+        run: |
+          flatpak info io.github.win12_online.win12_desktop
+          flatpak run --command=sh io.github.win12_online.win12_desktop -c \
+            'test -x /app/bin/win12-desktop && test -x /app/bin/ping && test -x /app/bin/ping6'
+
+      - name: Create Flatpak bundle
+        run: |
+          flatpak build-bundle \
+            flatpak-repo \
+            win12-desktop.flatpak \
+            io.github.win12_online.win12_desktop \
+            --runtime-repo=https://flathub.org/repo/flathub.flatpakrepo
+
+      - name: Upload Flatpak artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: flatpak-bundles
+          path: win12-desktop.flatpak
+          if-no-files-found: error
+          retention-days: 5
+
   publish:
     name: Publish Release
-    needs: build
+    needs: [build, build-flatpak]
     runs-on: ubuntu-latest
 
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@v8
         with:
-          pattern: tauri-bundles-*
+          pattern: '*bundles*'
           path: ./artifact
           merge-multiple: true
       - name: Debug - list files


### PR DESCRIPTION
Add Flatpak build jobs to CI and release workflows, including dependency setup, installation checks, bundle creation, and artifact upload.

Include Flatpak manifest-related files in build workflow triggers and update release publishing to wait for Flatpak artifacts alongside Tauri bundles.